### PR TITLE
fix: Cloud Run auth

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,9 +47,19 @@ resource "google_cloud_run_service" "app" {
 }
 
 # Allow unauthenticated users to invoke the service
-resource "google_cloud_run_service_iam_member" "run_all_users" {
-  service  = google_cloud_run_service.app.name
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
   location = google_cloud_run_service.app.location
-  role     = "roles/run.invoker"
-  member   = "allUsers"
+  project  = google_cloud_run_service.app.project
+  service  = google_cloud_run_service.app.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
 }


### PR DESCRIPTION
Cloud Runのアクセス権付与でエラーが出る件
サービスアカウントの権限の問題だったため，Cloud Shellにて権限を付与した
アクセス権付与についてはTerraform公式の方法に戻す